### PR TITLE
Adding support for RV32A atomic operations (AMO*, LR, and SC)

### DIFF
--- a/riscvmodel/insn.py
+++ b/riscvmodel/insn.py
@@ -481,3 +481,91 @@ class InstructionCMV(InstructionCRType):
 
     def execute(self, model: Model):
         model.state.intreg[self.rd] = model.state.intreg[self.rs]
+
+
+@isa("lr", RV32A, opcode=0b0101111, funct7=0b0001011, funct3=0b010)
+class InstructionLR(InstructionRType):
+    """ Load reserved """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("sc", RV32A, opcode=0b0101111, funct7=0b0001111, funct3=0b010)
+class InstructionSC(InstructionRType):
+    """ Store conditional """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("amoadd", RV32A, opcode=0b0101111, funct5=0b00000, funct3=0b010)
+class InstructionAMOADD(InstructionAMOType):
+    """ Atomic swap operation """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("amoxor", RV32A, opcode=0b0101111, funct5=0b00100, funct3=0b010)
+class InstructionAMOXOR(InstructionAMOType):
+    """ Atomic swap operation """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("amoor",   RV32A, opcode=0b0101111, funct5=0b01000, funct3=0b010)
+class InstructionAMOOR(InstructionAMOType):
+    """ Atomic swap operation """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("amoand", RV32A, opcode=0b0101111, funct5=0b01100, funct3=0b010)
+class InstructionAMOAND(InstructionAMOType):
+    """ Atomic swap operation """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("amomin", RV32A, opcode=0b0101111, funct5=0b10000, funct3=0b010)
+class InstructionAMOMIN(InstructionAMOType):
+    """ Atomic swap operation """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("amomax", RV32A, opcode=0b0101111, funct5=0b10100, funct3=0b010)
+class InstructionAMOMAX(InstructionAMOType):
+    """ Atomic swap operation """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("amominu", RV32A, opcode=0b0101111, funct5=0b11000, funct3=0b010)
+class InstructionAMOMINU(InstructionAMOType):
+    """ Atomic swap operation """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("amomaxu", RV32A, opcode=0b0101111, funct5=0b11100, funct3=0b010)
+class InstructionAMOMAXU(InstructionAMOType):
+    """ Atomic swap operation """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass
+
+
+@isa("amoswap", RV32A, opcode=0b0101111, funct5=0b00001, funct3=0b010)
+class InstructionAMOSWAP(InstructionAMOType):
+    """ Atomic swap operation """
+    def execute(self, model: Model):
+        # TODO: implement
+        pass

--- a/riscvmodel/insn.py
+++ b/riscvmodel/insn.py
@@ -483,16 +483,16 @@ class InstructionCMV(InstructionCRType):
         model.state.intreg[self.rd] = model.state.intreg[self.rs]
 
 
-@isa("lr", RV32A, opcode=0b0101111, funct7=0b0001011, funct3=0b010)
-class InstructionLR(InstructionRType):
+@isa("lr", RV32A, opcode=0b0101111, funct5=0b00010, funct3=0b010)
+class InstructionLR(InstructionAMOType):
     """ Load reserved """
     def execute(self, model: Model):
         # TODO: implement
         pass
 
 
-@isa("sc", RV32A, opcode=0b0101111, funct7=0b0001111, funct3=0b010)
-class InstructionSC(InstructionRType):
+@isa("sc", RV32A, opcode=0b0101111, funct5=0b00011, funct3=0b010)
+class InstructionSC(InstructionAMOType):
     """ Store conditional """
     def execute(self, model: Model):
         # TODO: implement

--- a/riscvmodel/insn.py
+++ b/riscvmodel/insn.py
@@ -487,85 +487,186 @@ class InstructionCMV(InstructionCRType):
 class InstructionLR(InstructionAMOType):
     """ Load reserved """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # Perform a normal load
+        data = model.state.memory.lw(model.state.intreg[self.rs1].unsigned())
+        model.state.intreg[self.rd] = data
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("sc", RV32A, opcode=0b0101111, funct5=0b00011, funct3=0b010)
 class InstructionSC(InstructionAMOType):
     """ Store conditional """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # Check if this address is reserved
+        if model.state.atomic_reserved(model.state.intreg[self.rs1]):
+            model.state.memory.sw(
+                model.state.intreg[self.rs1].unsigned(),
+                model.state.intreg[self.rs2]
+            )
+            model.state.intreg[self.rd] = 0
+        else:
+            model.state.intreg[self.rd] = 1
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("amoadd", RV32A, opcode=0b0101111, funct5=0b00000, funct3=0b010)
 class InstructionAMOADD(InstructionAMOType):
-    """ Atomic swap operation """
+    """ Atomic add operation """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # This models a single HART with 1 stage pipeline, so will always succeed
+        model.state.intreg[self.rd] = model.state.memory.lw(
+            model.state.intreg[self.rs1].unsigned()
+        )
+        model.state.memory.sw(
+            model.state.intreg[self.rs1].unsigned(),
+            (model.state.intreg[self.rs2] + model.state.intreg[self.rd])
+        )
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("amoxor", RV32A, opcode=0b0101111, funct5=0b00100, funct3=0b010)
 class InstructionAMOXOR(InstructionAMOType):
-    """ Atomic swap operation """
+    """ Atomic XOR operation """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # This models a single HART with 1 stage pipeline, so will always succeed
+        model.state.intreg[self.rd] = model.state.memory.lw(
+            model.state.intreg[self.rs1].unsigned()
+        )
+        model.state.memory.sw(
+            model.state.intreg[self.rs1].unsigned(),
+            (model.state.intreg[self.rs2] ^ model.state.intreg[self.rd])
+        )
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("amoor",   RV32A, opcode=0b0101111, funct5=0b01000, funct3=0b010)
 class InstructionAMOOR(InstructionAMOType):
-    """ Atomic swap operation """
+    """ Atomic OR operation """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # This models a single HART with 1 stage pipeline, so will always succeed
+        model.state.intreg[self.rd] = model.state.memory.lw(
+            model.state.intreg[self.rs1].unsigned()
+        )
+        model.state.memory.sw(
+            model.state.intreg[self.rs1].unsigned(),
+            (model.state.intreg[self.rs2] | model.state.intreg[self.rd])
+        )
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("amoand", RV32A, opcode=0b0101111, funct5=0b01100, funct3=0b010)
 class InstructionAMOAND(InstructionAMOType):
-    """ Atomic swap operation """
+    """ Atomic AND operation """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # This models a single HART with 1 stage pipeline, so will always succeed
+        model.state.intreg[self.rd] = model.state.memory.lw(
+            model.state.intreg[self.rs1].unsigned()
+        )
+        model.state.memory.sw(
+            model.state.intreg[self.rs1].unsigned(),
+            (model.state.intreg[self.rs2] & model.state.intreg[self.rd])
+        )
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("amomin", RV32A, opcode=0b0101111, funct5=0b10000, funct3=0b010)
 class InstructionAMOMIN(InstructionAMOType):
-    """ Atomic swap operation """
+    """ Atomic minimum operation """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # This models a single HART with 1 stage pipeline, so will always succeed
+        model.state.intreg[self.rd] = model.state.memory.lw(
+            model.state.intreg[self.rs1].unsigned()
+        )
+        model.state.memory.sw(
+            model.state.intreg[self.rs1].unsigned(),
+            min(model.state.intreg[self.rs2], model.state.intreg[self.rd])
+        )
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("amomax", RV32A, opcode=0b0101111, funct5=0b10100, funct3=0b010)
 class InstructionAMOMAX(InstructionAMOType):
-    """ Atomic swap operation """
+    """ Atomic maximum operation """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # This models a single HART with 1 stage pipeline, so will always succeed
+        model.state.intreg[self.rd] = model.state.memory.lw(
+            model.state.intreg[self.rs1].unsigned()
+        )
+        model.state.memory.sw(
+            model.state.intreg[self.rs1].unsigned(),
+            max(model.state.intreg[self.rs2], model.state.intreg[self.rd])
+        )
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("amominu", RV32A, opcode=0b0101111, funct5=0b11000, funct3=0b010)
 class InstructionAMOMINU(InstructionAMOType):
-    """ Atomic swap operation """
+    """ Atomic unsigned minimum operation """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # This models a single HART with 1 stage pipeline, so will always succeed
+        model.state.intreg[self.rd] = model.state.memory.lw(
+            model.state.intreg[self.rs1].unsigned()
+        )
+        model.state.memory.sw(
+            model.state.intreg[self.rs1].unsigned(),
+            min(
+                model.state.intreg[self.rs2].unsigned(),
+                model.state.intreg[self.rd].unsigned()
+            )
+        )
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("amomaxu", RV32A, opcode=0b0101111, funct5=0b11100, funct3=0b010)
 class InstructionAMOMAXU(InstructionAMOType):
-    """ Atomic swap operation """
+    """ Atomic unsigned maximum operation """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # This models a single HART with 1 stage pipeline, so will always succeed
+        model.state.intreg[self.rd] = model.state.memory.lw(
+            model.state.intreg[self.rs1].unsigned()
+        )
+        model.state.memory.sw(
+            model.state.intreg[self.rs1].unsigned(),
+            max(
+                model.state.intreg[self.rs2].unsigned(),
+                model.state.intreg[self.rd].unsigned()
+            )
+        )
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])
 
 
 @isa("amoswap", RV32A, opcode=0b0101111, funct5=0b00001, funct3=0b010)
 class InstructionAMOSWAP(InstructionAMOType):
     """ Atomic swap operation """
     def execute(self, model: Model):
-        # TODO: implement
-        pass
+        # This models a single HART with 1 stage pipeline, so will always succeed
+        model.state.intreg[self.rd] = model.state.memory.lw(
+            model.state.intreg[self.rs1].unsigned()
+        )
+        model.state.memory.sw(
+            model.state.intreg[self.rs1].unsigned(),
+            model.state.intreg[self.rs2]
+        )
+        # Perform correct lock or release actions
+        if self.rl: model.state.atomic_release(model.state.intreg[self.rs1])
+        elif self.aq: model.state.atomic_acquire(model.state.intreg[self.rs1])

--- a/riscvmodel/isa.py
+++ b/riscvmodel/isa.py
@@ -851,10 +851,3 @@ def get_mnemomics():
     """
     return [i.mnemonic for i in get_insns()]
 
-class TerminateException(Exception):
-    """
-    Exception that signal the termination of the program
-    """
-    def __init__(self, returncode):
-        super().__init__()
-        self.returncode = returncode

--- a/riscvmodel/isa.py
+++ b/riscvmodel/isa.py
@@ -212,6 +212,9 @@ class Instruction(metaclass=ABCMeta):
 class InstructionFunct3Type(Instruction, metaclass=ABCMeta):
     field_funct3 = Field(name="funct3", base=12, size=3, description="", static=True)
 
+class InstructionFunct5Type(Instruction, metaclass=ABCMeta):
+    field_funct5 = Field(name="funct5", base=27, size=5, description="", static=True)
+
 class InstructionFunct7Type(Instruction, metaclass=ABCMeta):
     field_funct7 = Field(name="funct7", base=25, size=7, description="", static=True)
 
@@ -645,6 +648,79 @@ class InstructionCSSType(InstructionCType, metaclass=ABCMeta):
     def randomize(self, variant: Variant):
         self.rs = randrange(0, 16)
         self.imm.randomize()
+
+
+class InstructionAMOType(InstructionFunct3Type, InstructionFunct5Type, metaclass=ABCMeta):
+    """
+    AMO-type instructions used a modified version of the R-type instruction.
+    These are also 3-register instructions (use 2 source, write 1 output) but
+    have additional flags for controlling acquisition (aq) and release (rl) of
+    locks on target addresses.
+
+    :param rd: Destination register
+    :type rd: int
+    :param rs1: Source register 1
+    :type rs1: int
+    :param rs2: Source register 2
+    :type rs2: int
+    :param rl: Lock release flag
+    :type rl: int
+    :param aq: Lock acquisition flag
+    :type aq: int
+    """
+
+    isa_format_id     = "R"
+    asm_arg_signature = "<rd>, <rs1>, <rs2>, <rl>, <aq>"
+
+    field_rd  = Field(name="rd", base=7, size=5, description="")
+    field_rs1 = Field(name="rs1", base=15, size=5, description="")
+    field_rs2 = Field(name="rs2", base=20, size=5, description="")
+    field_rl  = Field(name="rl",  base=25, size=1, description="Lock release")
+    field_aq  = Field(name="aq",  base=26, size=1, description="Lock acquire")
+
+    def __init__(
+        self,
+        rd: int = None,
+        rs1: int = None,
+        rs2: int = None,
+        rl: int = None,
+        aq: int = None,
+    ):
+        super(InstructionAMOType, self).__init__()
+        self.rd  = rd
+        self.rs1 = rs1
+        self.rs2 = rs2
+        self.rl  = rl
+        self.aq  = aq
+
+    def ops_from_list(self, ops):
+        (self.rd, self.rs1, self.rs2, self.rl, self.aq) = [int(op[1:]) for ops in ops]
+
+    def randomize(self, variant: Variant):
+        self.rd  = randrange(0, variant.xlen)
+        self.rs1 = randrange(0, variant.xlen)
+        self.rs2 = randrange(0, variant.xlen)
+        self.rl  = randrange(0, variant.xlen)
+        self.aq  = randrange(0, variant.xlen)
+
+    def inopstr(self, model):
+        opstr = "{:>3}={}, ".format(
+            "x{}".format(self.rs1), model.state.intreg[self.rs1]
+        )
+        opstr += "{:>3}={} ".format(
+            "x{}".format(self.rs2), model.state.intreg[self.rs2]
+        )
+        return opstr
+
+    def outopstr(self, model):
+        return "{:>3}={} ".format(
+            "x{}".format(self.rd), model.state.intreg[self.rd]
+        )
+
+    def __str__(self):
+        return "{} x{}, x{}, x{}, {}, {}".format(
+            self.mnemonic, self.rd, self.rs1, self.rs2, self.rl, self.aq
+        )
 
 
 def isa(mnemonic: str,

--- a/riscvmodel/program/tests.py
+++ b/riscvmodel/program/tests.py
@@ -1,4 +1,5 @@
 from riscvmodel.isa import *
+from riscvmodel.insn import *
 from riscvmodel.regnames import *
 from riscvmodel.program import Program
 

--- a/riscvmodel/program/tests_atomic.py
+++ b/riscvmodel/program/tests_atomic.py
@@ -1,0 +1,25 @@
+from riscvmodel.isa import *
+from riscvmodel.insn import *
+from riscvmodel.regnames import *
+from riscvmodel.program import Program
+
+
+class LRSCTest(Program):
+    """Basic test of LR & SC instructions"""
+    def __init__(self):
+        super().__init__([
+            # Perform load-reserved and acquire lock
+            InstructionLR(rs1=x0, rd=x1, aq=1, rl=0),
+            # Perform store-conditional and release lock (should succeed)
+            InstructionSC(rs1=x0, rs2=x0, rd=x2, aq=0, rl=1),
+            # Perform second store-conditional to same address (should fail)
+            InstructionSC(rs1=x0, rs2=x0, rd=x3, aq=0, rl=1),
+        ])
+
+    def expects(self) -> dict:
+        return {
+            x0: 0,
+            x2: 0, # Due to successful SC (2nd instruction)
+            x3: 1, # Due to failed SC (3rd instruction)
+        }
+

--- a/riscvmodel/variant.py
+++ b/riscvmodel/variant.py
@@ -28,7 +28,7 @@ class Variant:
         "Zifencei": Extension("Zifencei", "Instruction-Fetch Fence", [])
     }
     regex = re.compile(
-        r"^RV(32|64|128)(I|E|G)({})*((?:(?:Z|X).+)(?:_(?:(?:Z|X).*))*)?$".
+        r"^RV(32|64|128)(A|I|E|G)({})*((?:(?:Z|X).+)(?:_(?:(?:Z|X).*))*)?$".
         format("|".join(list(stdext.keys()) + ["G"])))
     G_expand = ["I", "M", "A", "F", "D", "Zicsr", "Zifencei"]
 
@@ -133,6 +133,7 @@ RV64I = Variant("RV64I")
 RV64G = Variant("RV64G")
 RV64GC = Variant("RV64GC")
 RV128I = Variant("RV128I")
+RV32A = Variant("RV32A")
 
 
 def describe_argparser():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 from riscvmodel.program.tests import *
+from riscvmodel.program.tests_atomic import *
 from riscvmodel.model import Model
-from riscvmodel.variant import RV32I
+from riscvmodel.variant import RV32I, RV32A
 
 import pytest
 
@@ -19,5 +20,13 @@ def check_model(model: Model, check: dict):
 def test_model_addi():
     pgm = ADDITest()
     m = Model(RV32I)
+    m.execute(pgm)
+    check_model(m, pgm.expects())
+
+
+def test_model_lr_sc():
+    """Test if load-reserved and store-conditional sequence works"""
+    pgm = LRSCTest()
+    m   = Model(RV32A)
     m.execute(pgm)
     check_model(m, pgm.expects())


### PR DESCRIPTION
These changes add RV32A atomic operations support.

I'm not sure if this is the best way to manage ISA extensions - whether these should be included within `insn.py`, or whether it would be better to create extension specific instruction files, e.g. `insn_a.py`.