### PR TITLE
Fix import of TerminateException in sim.py

### DIFF
--- a/riscvmodel/sim.py
+++ b/riscvmodel/sim.py
@@ -1,5 +1,4 @@
-from .model import Model, Memory
-from .isa import TerminateException
+from .model import Model, Memory, TerminateException
 
 import struct
 


### PR DESCRIPTION
This was broken in commit a5328f4, which got merged into master and
then released.