### PR TITLE
Fix encoding for J-type instructions

### DIFF
--- a/riscvmodel/isa.py
+++ b/riscvmodel/isa.py
@@ -533,7 +533,7 @@ class InstructionJType(Instruction, metaclass=ABCMeta):
     """
 
     field_rd = Field(name="rd", base=7, size=5, description="")
-    field_imm = Field(name="imm", base=[21,20,12,31], size=[10,1,8,1], description="")
+    field_imm = Field(name="imm", base=[21,20,12,31], size=[10,1,8,1], description="", offset=1)
 
     def __init__(self, rd: int = None, imm: int = None):
         super(InstructionJType, self).__init__()


### PR DESCRIPTION
The immediate (as well as being scattered crazily through the
encoding!) has an offset of 1.